### PR TITLE
Add support for Coffee machines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It (currently) requires a
 - Miele Fridge.
 - Miele Freezer (e.g. FN28263).
 - Miele Fridge Freezer combination.
+- Miele Coffee machine (e.g. CVA7845).
 
 ## Features
 - Easy setup: guided process to retrieve token via OAuth2 from Miele.
@@ -67,7 +68,7 @@ Fridge / Freezer / Fridge Freezer combination:
 - [Wiki](../../wiki/)
 
 ## Planned features
-- Add support for oven, hob and coffee machine?
+- Add support for oven and hob.
 - Add Custom characteristic to display current program running.
 
 ## Thanks

--- a/src/mieleCharacteristics.ts
+++ b/src/mieleCharacteristics.ts
@@ -151,6 +151,23 @@ export class MieleInUseCharacteristic extends MieleBinaryStateCharacteristic {
   }
 }
 
+
+//-------------------------------------------------------------------------------------------------
+// Miele OutletInUse Characteristic. 
+//-------------------------------------------------------------------------------------------------
+export class MieleOutletInUseCharacteristic extends MieleBinaryStateCharacteristic {
+      
+  constructor(
+    platform: MieleAtHomePlatform,
+    service: Service,
+    inactiveStates: MieleState[] | null,
+    activeStates: MieleState[] | null,
+  ) {
+    super(platform, service, inactiveStates, activeStates, platform.Characteristic.OutletInUse, 0, 1);
+  }
+}
+
+
 //-------------------------------------------------------------------------------------------------
 // Miele Current Cooling Characteristic. 
 //-------------------------------------------------------------------------------------------------
@@ -464,9 +481,9 @@ export class MieleTemperatureUnitCharacteristic extends MieleBaseCharacteristic 
 
 
 //-------------------------------------------------------------------------------------------------
-// Base class: Miele Power Characteristic
+// Base class: Miele On Characteristic
 //-------------------------------------------------------------------------------------------------
-export class MielePowerCharacteristic extends MieleBaseCharacteristic {      
+export class MieleOnCharacteristic extends MieleBaseCharacteristic {      
   
   constructor(
     platform: MieleAtHomePlatform,
@@ -492,6 +509,7 @@ export class MielePowerCharacteristic extends MieleBaseCharacteristic {
         const response = await axios.put(this.platform.getActionsUrl(this.serialNumber), data,
           this.platform.getHttpRequestConfig());
         this.platform.log.debug(`${this.deviceName}: Process action response code: ${response.status}: "${response.statusText}"`);
+        this.value = value;
 
       } else {
         this.platform.log.info(`${this.deviceName} (${this.serialNumber}): ` +

--- a/src/mieleCharacteristics.ts
+++ b/src/mieleCharacteristics.ts
@@ -62,7 +62,7 @@ abstract class MieleBaseCharacteristic implements IMieleCharacteristic {
 
   //-------------------------------------------------------------------------------------------------
   // Update value only when not equal to cached value.
-  protected updateCharacteristic(value: string | number, logInfo = true) {
+  protected updateCharacteristic(value: CharacteristicValue, logInfo = true) {
     if(value!==this.value) {
       const logStr = `${this.deviceName}: Updating characteristic ${this.characteristic.name} to ${value}.`;
       if(logInfo) {
@@ -460,4 +460,56 @@ export class MieleTemperatureUnitCharacteristic extends MieleBaseCharacteristic 
     this.updateCharacteristic(value);
   }
 
+}
+
+
+//-------------------------------------------------------------------------------------------------
+// Base class: Miele Power Characteristic
+//-------------------------------------------------------------------------------------------------
+export class MielePowerCharacteristic extends MieleBaseCharacteristic {      
+  
+  constructor(
+    platform: MieleAtHomePlatform,
+    service: Service,
+    private serialNumber: string,
+  ) {
+    super(platform, service, platform.Characteristic.On, false);
+  }
+
+  async set(value: CharacteristicValue, callback: CharacteristicSetCallback) {
+    this.platform.log.debug(`${this.deviceName}: Set characteristic ${this.characteristic.name} to: ${value}`);
+
+    callback(null);
+
+    try {
+      const response = await axios.get(this.platform.getActionsUrl(this.serialNumber),
+        this.platform.getHttpRequestConfig());
+
+      const action = value ? "powerOn" : "powerOff";
+      if (response.data[action]) {
+        const data = {};
+        data[action] = true;
+        const response = await axios.put(this.platform.getActionsUrl(this.serialNumber), data,
+          this.platform.getHttpRequestConfig());
+        this.platform.log.debug(`${this.deviceName}: Process action response code: ${response.status}: "${response.statusText}"`);
+
+      } else {
+        this.platform.log.info(`${this.deviceName} (${this.serialNumber}): ` +
+          `Ignoring request to power ${value ? 'on' : 'off'} the device: not allowed in current device state. ` +
+          `Allowed power actions: on=${response.data.powerOn}, off=${response.data.powerOff}`);
+        this.undoSetState(value);
+      }
+
+    } catch (error) {
+      this.platform.log.error(createErrorString(error));
+      this.undoSetState(value);
+    }
+  }
+
+  update(response: MieleStatusResponse): void {
+    this.platform.log.debug(`${this.deviceName}: Update received for ${this.characteristic.name} raw value: ${response.status.value_raw}.`);
+
+    const value = response.status.value_raw !== MieleState.Off;
+    this.updateCharacteristic(value);
+  }
 }

--- a/src/mieleCoffeeSystemPlatformAccessory.ts
+++ b/src/mieleCoffeeSystemPlatformAccessory.ts
@@ -1,0 +1,42 @@
+// Apacche License
+// Copyright (c) 2021, Arkadiusz Wahlig
+
+import { PlatformAccessory } from 'homebridge';
+
+import { MieleAtHomePlatform } from './platform';
+import { MieleBasePlatformAccessory } from './mieleBasePlatformAccessory';
+
+import { MielePowerCharacteristic } from './mieleCharacteristics';
+
+//-------------------------------------------------------------------------------------------------
+// Class Coffee System
+//-------------------------------------------------------------------------------------------------
+export class MieleCoffeeSystemPlatformAccessory extends MieleBasePlatformAccessory {
+
+  //-----------------------------------------------------------------------------------------------
+  constructor(
+    platform: MieleAtHomePlatform,
+    accessory: PlatformAccessory,
+  ) {
+    super(platform, accessory);
+
+    this.mainService = this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch);
+
+    // Set the service name, this is what is displayed as the default name on the Home app
+    this.mainService.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.displayName);
+
+    const powerCharacteristic = new MielePowerCharacteristic(this.platform, this.mainService, accessory.context.device.uniqueId);
+
+    this.characteristics.push(powerCharacteristic);
+
+    // Each service must implement at-minimum the "required characteristics" for the given service type
+    // see https://developers.homebridge.io/#/service/Switch
+    this.mainService.getCharacteristic(this.platform.Characteristic.On)
+      .on('get', powerCharacteristic.get.bind(powerCharacteristic))
+      .on('set', powerCharacteristic.set.bind(powerCharacteristic));
+  }
+  
+}
+
+

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -7,6 +7,7 @@ import { PLATFORM_NAME, PLUGIN_NAME, DEVICES_INFO_URL, DEFAULT_RECONNECT_EVENT_S
 import { MieleHoodPlatformAccessory } from './mieleHoodPlatformAccessory';
 import { MieleWasherDryerPlatformAccessory } from './mieleWasherDryerPlatformAccessory';
 import { MieleFridgePlatformAccessory } from './mieleFridgePlatformAccessory';
+import { MieleCoffeeSystemPlatformAccessory } from './mieleCoffeeSystemPlatformAccessory';
 import { Token } from './token';
 
 import axios from 'axios';
@@ -32,6 +33,7 @@ enum MieleDeviceIds {
   Washer = 1,
   Dryer = 2,
   Dishwasher = 7,
+  CoffeeSystem = 17,
   Hood = 18,
   Fridge = 19,
   Freezer = 20,
@@ -211,6 +213,9 @@ export class MieleAtHomePlatform implements DynamicPlatformPlugin {
           this.disableStopActionFor.includes(MieleDeviceIds[raw_id]),
           this.disableSetTargetTempFor.includes(MieleDeviceIds[raw_id]));
 
+      case MieleDeviceIds.CoffeeSystem:
+        return new MieleCoffeeSystemPlatformAccessory(this, accessory);
+    
       default:
         return null;
       


### PR DESCRIPTION
Adds support for Miele Coffee System (type=17) devices, i.e. Coffee machines.

Uses HomeKit Outlet service to represent them and to power them on and off.

Additionally, the OutletInUse characteristic is set to true whenever the machine is in use.

Unfortunately, I don't think there's a way to start preparing a drink remotely. Still, being able to power them on is useful because they take a while to run through the startup cleaning routine before they're ready to make drinks. With this I can make sure mine is already on when I go into the kitchen in the morning.